### PR TITLE
Stub node if it has callbacks or listListeners.

### DIFF
--- a/lib/src/responder/simple/simple_node.dart
+++ b/lib/src/responder/simple/simple_node.dart
@@ -641,7 +641,7 @@ class SimpleNodeProvider extends NodeProviderImpl
       pnode.updateList(p.name);
     }
 
-    if (node.callbacks.isEmpty) {
+    if (node.callbacks.isEmpty && !node._hasListListener) {
       nodes.remove(path);
     } else {
       node._stub = true;


### PR DESCRIPTION
Prevents node with active listeners from being removed while still open.