### PR TITLE
Re-assign BroadcastStream callbacks when copying stub nodes.

### DIFF
--- a/lib/src/responder/node_provider.dart
+++ b/lib/src/responder/node_provider.dart
@@ -10,10 +10,8 @@ abstract class LocalNode extends Node {
     if (_listChangeController == null) {
       _listChangeController = new BroadcastStreamController<String>(
         () {
-          _hasListListener = true;
           onStartListListen();
         }, () {
-          _hasListListener = false;
           onAllListCancel();
         }, null, true);
     }
@@ -34,7 +32,7 @@ abstract class LocalNode extends Node {
   /// Callback for when all lists are canceled.
   void onAllListCancel() {}
 
-  bool _hasListListener = false;
+  bool get _hasListListener => _listChangeController?.hasListener ?? false;
 
   /// Node Provider
   NodeProvider get provider;

--- a/lib/src/responder/simple/simple_node.dart
+++ b/lib/src/responder/simple/simple_node.dart
@@ -576,6 +576,12 @@ class SimpleNodeProvider extends NodeProviderImpl
       if (node is SimpleNode) {
         try {
           node._listChangeController = oldNode._listChangeController;
+          node._listChangeController.onStartListen = () {
+            node.onStartListListen();
+          };
+          node._listChangeController.onAllCancel = () {
+            node.onAllListCancel();
+          };
         } catch (e) {}
 
         if (node._hasListListener) {

--- a/lib/src/utils/stream_controller.dart
+++ b/lib/src/utils/stream_controller.dart
@@ -5,8 +5,8 @@ class BroadcastStreamController<T> implements StreamController<T> {
   CachedStreamWrapper<T> _stream;
   Stream<T> get stream => _stream;
 
-  Function _onStartListen;
-  Function _onAllCancel;
+  Function onStartListen;
+  Function onAllCancel;
 
   BroadcastStreamController([
     void onStartListen(),
@@ -19,8 +19,8 @@ class BroadcastStreamController<T> implements StreamController<T> {
         _controller.stream
             .asBroadcastStream(onListen: _onListen, onCancel: _onCancel),
         onListen);
-    _onStartListen = onStartListen;
-    _onAllCancel = onAllCancel;
+    this.onStartListen = onStartListen;
+    this.onAllCancel = onAllCancel;
   }
 
   /// whether there is listener or not
@@ -30,8 +30,8 @@ class BroadcastStreamController<T> implements StreamController<T> {
   bool _listenState = false;
   void _onListen(StreamSubscription<T> subscription) {
     if (!_listenState) {
-      if (_onStartListen != null) {
-        _onStartListen();
+      if (onStartListen != null) {
+        onStartListen();
       }
       _listenState = true;
     }
@@ -40,7 +40,7 @@ class BroadcastStreamController<T> implements StreamController<T> {
 
   void _onCancel(StreamSubscription<T> subscription) {
     _listening = false;
-    if (_onAllCancel != null) {
+    if (onAllCancel != null) {
       if (!_delayedCheckCanceling) {
         _delayedCheckCanceling = true;
         DsTimer.callLater(delayedCheckCancel);
@@ -54,7 +54,7 @@ class BroadcastStreamController<T> implements StreamController<T> {
   void delayedCheckCancel() {
     _delayedCheckCanceling = false;
     if (!_listening && _listenState) {
-      _onAllCancel();
+      onAllCancel();
       _listenState = false;
     }
   }


### PR DESCRIPTION
Need to re-assign them because otherwise the closure closes over the
stub instance and uses its version of onStartListListen and onAllListCancel
rather than the one in the valid node.