### PR TITLE
Fix strong mode compliance and adds check for when the websocket is closed.

### DIFF
--- a/.analysis_options
+++ b/.analysis_options
@@ -1,2 +1,4 @@
 analyzer:
-  strong-mode: false
+  strong-mode: true
+  exclude:
+  - 'tool/experiment/**'

--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ doc/
 /defs.json
 /storage/
 /tmp
+.atom/

--- a/example/browser/video.dart
+++ b/example/browser/video.dart
@@ -16,9 +16,17 @@ main() async {
   video = querySelector("#video");
   videoObject = new JsObject.fromBrowserObject(video);
 
-  var brokerUrl = await BrowserUtils.fetchBrokerUrlFromPath("broker_url", "http://localhost:8080/conn");
+  var brokerUrl = await BrowserUtils.fetchBrokerUrlFromPath(
+    "broker_url",
+    "http://localhost:8080/conn"
+  );
 
-  link = new LinkProvider(brokerUrl, "VideoDisplay-", isRequester: true, isResponder: false);
+  link = new LinkProvider(
+    brokerUrl,
+    "VideoDisplay-",
+    isRequester: true,
+    isResponder: false
+  );
 
   await link.connect();
   requester = await link.onRequesterReady;

--- a/lib/broker_discovery.dart
+++ b/lib/broker_discovery.dart
@@ -38,10 +38,11 @@ class BrokerDiscoveryClient {
     try {
       for (var interface in interfaces) {
         try {
-          _socket.joinMulticast(new InternetAddress("239.255.255.230"), interface: interface);
-        } catch (e) {
-          _socket.joinMulticast(new InternetAddress("239.255.255.230"), interface: interface);
-        }
+          _socket.joinMulticast(
+            new InternetAddress("239.255.255.230"),
+            interface
+          );
+        } catch (e) {}
       }
     } catch (e) {
       _socket.joinMulticast(new InternetAddress("239.255.255.230"));

--- a/lib/nodes.dart
+++ b/lib/nodes.dart
@@ -153,7 +153,7 @@ class ResolvingNodeProvider extends SimpleNodeProvider {
     LocalNode node = super.getNode(path);
     if (path != "/" && node != null && !forceHandle) {
       if (onLoaded != null && !onLoaded.isCompleted) {
-        onLoaded.complete(node);
+        onLoaded.complete(node as CallbackNode);
       }
       return node;
     }

--- a/lib/src/historian/rollup.dart
+++ b/lib/src/historian/rollup.dart
@@ -114,7 +114,14 @@ class MaxRollup extends Rollup {
       return;
     }
 
-    value = max(value == null ? double.INFINITY : value, input);
+    num left = double.INFINITY;
+    num right = input;
+
+    if (value is num) {
+      left = value;
+    }
+
+    value = max(left, right);
   }
 
   @override
@@ -136,7 +143,14 @@ class MinRollup extends Rollup {
       return;
     }
 
-    value = min(value == null ? double.NEGATIVE_INFINITY : value, input);
+    num left = double.NEGATIVE_INFINITY;
+    num right = input;
+
+    if (value is num) {
+      left = value;
+    }
+
+    value = min(left, right);
   }
 
   @override

--- a/lib/src/http/websocket_conn.dart
+++ b/lib/src/http/websocket_conn.dart
@@ -77,7 +77,7 @@ class WebSocketConnection extends Connection {
 
   void onPingTimer(Timer t) {
     if (_dataReceiveCount >= 3) {
-      logger.finest('close stale connection');
+      logger.finest("Closing stale connection.");
       this.close();
       return;
     }
@@ -135,7 +135,7 @@ class WebSocketConnection extends Connection {
         }
       } catch (err, stack) {
         logger.fine(
-          formatLogMessage("Failed to decode binary data in WebSocket Connection"),
+          formatLogMessage("Failed to decode binary data in WebSocket Connection."),
           err,
           stack
         );
@@ -188,7 +188,9 @@ class WebSocketConnection extends Connection {
         }
       } catch (err, stack) {
         logger.severe(
-          formatLogMessage("Failed to decode string data from WebSocket Connection"),
+          formatLogMessage(
+            "Failed to decode string data from WebSocket Connection."
+          ),
           err,
           stack
         );
@@ -334,13 +336,22 @@ class WebSocketConnection extends Connection {
       } else if (encoded is List<int>) {
         dataOut += encoded.length;
       } else {
-        logger.warning(formatLogMessage("invalid data frame"));
+        logger.warning(formatLogMessage("Invalid data frame."));
       }
     }
+
+    if (socket.readyState != WebSocket.OPEN) {
+      logger.severe(
+        formatLogMessage("Error writing to socket: socket is closed.")
+      );
+      close();
+      return;
+    }
+
     try {
       socket.add(encoded);
     } catch (e) {
-      logger.severe(formatLogMessage('Error writing to socket'), e);
+      logger.severe(formatLogMessage("Error writing to socket."), e);
       close();
     }
   }
@@ -399,6 +410,7 @@ class WebSocketConnection extends Connection {
   void close() {
     if (socket.readyState == WebSocket.OPEN ||
         socket.readyState == WebSocket.CONNECTING) {
+      logger.finest("Closing WebSocket connection.");
       socket.close();
     }
     _onDone();

--- a/lib/src/requester/request/subscribe.dart
+++ b/lib/src/requester/request/subscribe.dart
@@ -1,6 +1,6 @@
 part of dslink.requester;
 
-class ReqSubscribeListener implements StreamSubscription {
+class ReqSubscribeListener implements StreamSubscription<ValueUpdate> {
   ValueUpdateCallback callback;
   Requester requester;
   String path;
@@ -15,8 +15,8 @@ class ReqSubscribeListener implements StreamSubscription {
     return null;
   }
 
-  // TODO: define a custom class to replace StreamSubscription
-  Future asFuture([futureValue]) {
+  // TODO: define a custom class to replace StreamSubscription.
+  Future<dynamic/*=E*/> asFuture/*<E>*/([/*=E*/ dynamic futureValue]) {
     return null;
   }
 

--- a/lib/src/storage/simple_storage.dart
+++ b/lib/src/storage/simple_storage.dart
@@ -262,7 +262,6 @@ class SimpleValueStorageBucket implements IValueStorageBucket {
   }
 }
 
-
 class SimpleValueStorage extends IValueStorage {
   String key;
   SimpleValueStorageBucket bucket;
@@ -273,7 +272,6 @@ class SimpleValueStorage extends IValueStorage {
   }
   bool _pendingSet = false;
   Object _pendingValue;
-  Object _setValue;
 
   /// set the value, if previous setting is not finished, it will be set later
   void setValue(Object value) {
@@ -281,11 +279,13 @@ class SimpleValueStorage extends IValueStorage {
     if (_pendingSet) {
       return;
     }
-    _setValue = value;
     _pendingValue = null;
     _pendingSet = true;
-    _file.writeAsString(DsJson.encode(value)).then(onSetDone).catchError(onSetDone);
+    _file.writeAsString(
+      DsJson.encode(value)
+    ).then(onSetDone).catchError(onSetDone);
   }
+
   void onSetDone(Object obj) {
     _pendingSet = false;
     if (_pendingValue != null) {
@@ -295,7 +295,6 @@ class SimpleValueStorage extends IValueStorage {
 
   void destroy() {
     _pendingValue = null;
-    _setValue = null;
     _file.delete().catchError(_ignoreError);
   }
 

--- a/lib/src/utils/timer.dart
+++ b/lib/src/utils/timer.dart
@@ -1,8 +1,10 @@
 part of dslink.utils;
 
 class TimerFunctions extends LinkedListEntry<TimerFunctions> {
-  /// for better performance, use a low accuracy timer, ts50 is the floor of ts/50
+  /// for better performance, use a low accuracy timer.
+  /// ts50 is the floor of ts / 50
   final int ts50;
+
   List<Function> _functions = new List<Function>();
 
   TimerFunctions(this.ts50);
@@ -27,10 +29,7 @@ class DsTimer {
     return new Future.delayed(time, action);
   }
 
-  // TODO: does it need to use another hashset for quick search?
   static List<Function> _callbacks = [];
-
-  //static Map<Function, int> _timerCallbacks = new Map<Function, int>();
 
   static void _startTimer() {
     Timer.run(_dsLoop);
@@ -43,20 +42,6 @@ class DsTimer {
     }
     _callbacks.add(callback);
   }
-
-//  /// call the function and remove it from the pending listh
-//  static void callNow(Function callback) {
-//    if (_callbacks.contains(callback)) {
-//      _callbacks.remove(callback);
-//    }
-//    callback();
-//  }
-//
-//  static void cancel(Function callback) {
-//    if (_callbacks.contains(callback)) {
-//      _callbacks.remove(callback);
-//    }
-//  }
 
   static LinkedList<TimerFunctions> _pendingTimer =
       new LinkedList<TimerFunctions>();
@@ -109,8 +94,8 @@ class DsTimer {
         _functionsMap.remove(fun);
         try{
           fun();
-        } catch(err,stack) {
-          print("callback error; $err\n$stack");
+        } catch(err, stack) {
+          logger.warning("Timer callback error.", err, stack);
         }
       }
       return rslt;
@@ -218,7 +203,7 @@ class DsTimer {
     int currentTime = (new DateTime.now()).millisecondsSinceEpoch;
     _lastTimeRun = (currentTime / 50).floor();
     while (_removeTimerFunctions(_lastTimeRun) != null) {
-      // run the timer functions, empty loop
+      // run the timer functions, empty loop.
     }
 
     _looping = false;
@@ -234,7 +219,10 @@ class DsTimer {
           if (timerTimer != null && timerTimer.isActive) {
             timerTimer.cancel();
           }
-          var duration = new Duration(milliseconds: timerTs50 * 50 + 1 - currentTime);
+
+          var duration = new Duration(
+            milliseconds: timerTs50 * 50 + 1 - currentTime
+          );
           timerTimer = new Timer(duration, _startTimer);
         }
       }

--- a/test/large_links_test.dart
+++ b/test/large_links_test.dart
@@ -19,7 +19,7 @@ largeLinksTest() {
   DsHttpServer server;
   int port;
   setUp(() async {
-    updateLogLevel("WARNING");
+    updateLogLevel("WARN");
     port = await getRandomSocketPort();
     server = await startBrokerServer(port, persist: false);
   });
@@ -100,7 +100,6 @@ largeLinksTest() {
     }
 
     await gap();
-
     sub.cancel();
 
     expect(received, equals(sent));


### PR DESCRIPTION
This PR fixes strong mode compliance, and adds a check in the WebSocket connection to ensure that the socket is not closed.
As per dart-lang/sdk#29554, adding to the WebSocket sink will throw an error. Rather than catch this error when adding the data, checking proactively allows to give a more detailed message. You will notice that the error handler also calls `close()` on `WebSocketConnection`... this is because the done handler might not have been called, so we need to make sure we call it.
