### PR TITLE
Fix a type error in CallbackNode

### DIFF
--- a/lib/nodes.dart
+++ b/lib/nodes.dart
@@ -275,7 +275,7 @@ class CallbackNode extends SimpleNode implements WaitForMe {
       SimpleCallback onRemoving,
       LoadChildCallback onLoadChild,
       SimpleCallback onSubscribe,
-      ValueUpdateCallback<bool> onValueSet,
+      ValueCallback<bool> onValueSet,
       SimpleCallback onUnsubscribe})
       : onChildAddedCallback = onChildAdded,
         onChildRemovedCallback = onChildRemoved,

--- a/lib/src/common/value.dart
+++ b/lib/src/common/value.dart
@@ -1,6 +1,7 @@
 part of dslink.common;
 
 typedef T ValueUpdateCallback<T>(ValueUpdate update);
+typedef T ValueCallback<T>(value);
 
 /// Represents an update to a value subscription.
 class ValueUpdate {


### PR DESCRIPTION
The wrong callback type is used in CallbackNode, so a supplied callback will actually get the raw value and not the ValueUpdate instance.
