### PR TITLE
expose the getter of open in WebsocketConnection so it can be used fr…

### DIFF
--- a/lib/src/browser/browser_ws_conn.dart
+++ b/lib/src/browser/browser_ws_conn.dart
@@ -78,6 +78,8 @@ class WebSocketConnection extends Connection {
   }
 
   bool _opened = false;
+  bool get opened => _opened;
+
   void _onOpen(Event e) {
     logger.info("Connected");
     _opened = true;


### PR DESCRIPTION
…om outside the lib