### PR TITLE
add global socket to worker

### DIFF
--- a/lib/worker.dart
+++ b/lib/worker.dart
@@ -295,6 +295,8 @@ class Worker {
 typedef Future<T> WorkerMethod<T>([argument]);
 
 class WorkerSocket extends Stream<dynamic> implements StreamSink<dynamic> {
+  static WorkerSocket globalSocket;
+
   final ReceivePort receiver;
   SendPort _sendPort;
 


### PR DESCRIPTION
move the global socket into the sdk.
this solves a circular dependency issue in the server project, where is global socket is defined in main dart file.