### PR TITLE
Always check if subscription QOS needs to be updated.

### DIFF
--- a/lib/src/requester/request/subscribe.dart
+++ b/lib/src/requester/request/subscribe.dart
@@ -275,12 +275,10 @@ class ReqSubscribeController {
       qosChanged = updateQos();
     } else {
       callbacks[callback] = qos;
-      int neededQos = qos;
-      if (currentQos > -1) {
-        neededQos |= currentQos;
+      if (qos > currentQos) {
+        qosChanged = true;
+        currentQos = qos;
       }
-      qosChanged = neededQos > currentQos;
-      currentQos = neededQos;
       if (_lastUpdate != null) {
         callback(_lastUpdate);
       }
@@ -303,14 +301,14 @@ class ReqSubscribeController {
   }
 
   bool updateQos() {
-    int qosCache = 0;
+    int maxQos = 0;
 
     for (var qos in callbacks.values) {
-      qosCache |= qos;
+      maxQos = (qos > maxQos ? qos : maxQos);
     }
 
-    if (qosCache != currentQos) {
-      currentQos = qosCache;
+    if (maxQos != currentQos) {
+      currentQos = maxQos;
       return true;
     }
     return false;

--- a/lib/src/requester/request/subscribe.dart
+++ b/lib/src/requester/request/subscribe.dart
@@ -271,12 +271,8 @@ class ReqSubscribeController {
     bool qosChanged = false;
 
     if (callbacks.containsKey(callback)) {
-      if (callbacks[callback] != 0) {
-        callbacks[callback] = qos;
-        qosChanged = updateQos();
-      } else {
-        callbacks[callback] = qos;
-      }
+      callbacks[callback] = qos;
+      qosChanged = updateQos();
     } else {
       callbacks[callback] = qos;
       int neededQos = qos;


### PR DESCRIPTION
Previous behaviour would only check if QOS needed to be updated if
the existing QOS was 1 or higher. Thus if upgrading from 1 to 2 it
would send the update, but if QOS was 0 upgrading to 2, it would
not.