### PR TITLE
Fix issue with list subscriptions not updating a replaced node.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,5 @@
 # ChangeLog
 
+* v1.0.1 - Fix bug in list subscriptions for nodes which have been removed and recreated throughout subscription's life.
+           This may have prevented list subscriptions from updating full entries. 
 * v1.0.0 - Start of changelog tracking. Too many existing changes to list.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: dslink
-version: 1.0.0+1
+version: 1.0.1
 description: "DSA IoT Platform - DSLink SDK for Dart"
 homepage: "http://iot-dsa.org"
 documentation: "https://iot-dsa.github.io/docs/sdks/dart/"


### PR DESCRIPTION
If a list subscription existed on a node which had been removed and replaced with a new node,
the list subscription would continuing sending updates for the old node object.

Also remove some redundent else clauses.