### PR TITLE
Forward Subscription QOS changes to node within the subscription.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # ChangeLog
 
+* v1.0.2 - Properly forward QOS level changes to nodes when changing an existing subscription QOS level.
 * v1.0.1 - Fix bug in list subscriptions for nodes which have been removed and recreated throughout subscription's life.
            This may have prevented list subscriptions from updating full entries. 
 * v1.0.0 - Start of changelog tracking. Too many existing changes to list.

--- a/lib/src/responder/response/subscribe.dart
+++ b/lib/src/responder/response/subscribe.dart
@@ -218,6 +218,7 @@ class RespSubscribeController {
     caching = (v > 0);
     cachingQueue = (v > 1);
     persist = (v > 2);
+    _listener = node.subscribe(addValue, _qosLevel);
   }
 
   bool _caching = false;
@@ -250,7 +251,6 @@ class RespSubscribeController {
   RespSubscribeController(this.response, this.node, this.sid, this._permitted,
       int qos) {
     this.qosLevel = qos;
-    _listener = node.subscribe(addValue, _qosLevel);
     if (node.valueReady && node.lastValueUpdate != null) {
       addValue(node.lastValueUpdate);
     }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: dslink
-version: 1.0.1
+version: 1.0.2
 description: "DSA IoT Platform - DSLink SDK for Dart"
 homepage: "http://iot-dsa.org"
 documentation: "https://iot-dsa.github.io/docs/sdks/dart/"


### PR DESCRIPTION
Previously node would implement changes locally (eg local broker)
however a broker would not forward QOS change to remote responder.
This only occurred when upgrading an existing subscription, and
not when a new subscription was started with the correct QOS level.

By moving the node.subscribe from constructor to the QOS setting it ensures that subscription happens anytime QOS is change and not just on initial connect. This is safe as RemoteNodeLink just overwrites any existing callback with the QOS level rather than appending.