### PR TITLE
use blankData from the codec

### DIFF
--- a/lib/src/browser/browser_ws_conn.dart
+++ b/lib/src/browser/browser_ws_conn.dart
@@ -88,7 +88,7 @@ class WebSocketConnection extends Connection {
     }
     _responderChannel.updateConnect();
     _requesterChannel.updateConnect();
-    socket.sendString("{}");
+    socket.sendString(codec.blankData);
     requireSend();
   }
 


### PR DESCRIPTION
current code would send a string frame in websocket even when it's using msgpack codec.
the server can still parse it, that's why it didn't cause any bug.  but it's still better to fix it.